### PR TITLE
Upgrade to elastic 8.5.0 and keep using http

### DIFF
--- a/templates/storage/elasticsearch/configMap.yaml
+++ b/templates/storage/elasticsearch/configMap.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "finala.fullname" . }}-elasticsearch-config
+  labels:
+    chart: "{{ .Chart.Name }}"
+    app: "{{ include "finala.fullname" . }}-elasticsearch"
+data:
+{{- range $path, $config := .Values.storage.esConfig }}
+  {{ $path }}: |
+{{ $config | indent 4 -}}
+{{- end -}}

--- a/templates/storage/elasticsearch/elasticsearch.yaml
+++ b/templates/storage/elasticsearch/elasticsearch.yaml
@@ -15,9 +15,26 @@ spec:
       labels:
         component: {{ include "finala.fullname" . }}-elasticsearch
     spec:
+      volumes:
+        - name: esconfig
+          configMap:
+            name: {{ include "finala.fullname" . }}-elasticsearch-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: NodeType
+                    operator: In
+                    values:
+                      - gitops
+      tolerations:
+        - key: "gitops"
+          value: "true"
+          effect: "NoSchedule"
       containers:
       - name: {{ include "finala.fullname" . }}-elasticsearch
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.7.0
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.5.0
         env:
         - name: discovery.type
           value: single-node
@@ -29,4 +46,10 @@ spec:
           requests:
             cpu: 500m
             memory: 1Gi
+        volumeMounts:
+        {{- range $path, $config := .Values.storage.esConfig }}
+        - name: esconfig
+          mountPath: /usr/share/elasticsearch/config/{{ $path }}
+          subPath: {{ $path }}
+        {{- end -}}
 {{- end }}

--- a/templates/storage/elasticsearch/elasticsearch.yaml
+++ b/templates/storage/elasticsearch/elasticsearch.yaml
@@ -19,19 +19,6 @@ spec:
         - name: esconfig
           configMap:
             name: {{ include "finala.fullname" . }}-elasticsearch-config
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: NodeType
-                    operator: In
-                    values:
-                      - gitops
-      tolerations:
-        - key: "gitops"
-          value: "true"
-          effect: "NoSchedule"
       containers:
       - name: {{ include "finala.fullname" . }}-elasticsearch
         image: docker.elastic.co/elasticsearch/elasticsearch:8.5.0

--- a/values.yaml
+++ b/values.yaml
@@ -13,6 +13,13 @@ fullnameOverride: ""
 
 storage:
   type: internal
+  # Elasticsearch application configurations for http access. Remove for https and add other configurations. Example: https://github.com/elastic/helm-charts/blob/7.17/elasticsearch/examples/security/values.yaml
+  esConfig:
+    elasticsearch.yml: |
+      network.host: 0.0.0.0
+      xpack.security.enabled: false
+      xpack.security.http.ssl.enabled: false
+      xpack.security.transport.ssl.enabled: false
 
 api:
   create: true


### PR DESCRIPTION
Latest vulnerability found on elastic version 7.7.0:
https://nvd.nist.gov/vuln/detail/CVE-2021-44228

this pull request intends to upgrade to latest elasticsearch docker image (8.5.0). [LINK](https://hub.docker.com/_/elasticsearch)

Some changes been made to the new application, and elasticsearch from version '8' enforces ssl (HTTPS) by default. Adding some basic configuration to override it and keep using HTTP.